### PR TITLE
大佬，发现您的项目引入了com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer@20200713.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ujcms</groupId>
@@ -39,7 +37,7 @@
         <!-- HTML解析组件 -->
         <jsoup.version>1.14.2</jsoup.version>
         <!-- HTML不安全代码过滤组件 -->
-        <owasp-java-html-sanitizer.version>20200713.1</owasp-java-html-sanitizer.version>
+        <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>
         <!-- 安全框架 -->
         <shiro.version>1.8.0</shiro.version>
         <java-jwt.version>3.14.0</java-jwt.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Sanitize 安全漏洞
缺陷组件：com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer@20200713.1
漏洞编号：CVE-2021-42575
漏洞描述：Sanitize是美国Ryan Grove个人开发者的一款HTML和CSS清理器，它支持从字符串中删除HTML和CSS等。
OWASP Java HTML Sanitizer 存在安全漏洞，该漏洞源于20211018.1 之前的 OWASP Java HTML Sanitizer 没有正确执行与 SELECT、STYLE 和 OPTION 元素相关的策略。
影响范围：(∞, 20211018.2)
最小修复版本：20211018.2
缺陷组件引入路径：com.ujcms:ujcms@2.0.0->com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer@20200713.1
```
另外我运行这个项目时，IDE的安全插件提示还有1个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=padd58